### PR TITLE
automatically detect content-type if one isn't set

### DIFF
--- a/vk/error.go
+++ b/vk/error.go
@@ -33,20 +33,20 @@ func E(status int, message string) Error {
 // converts _something_ into bytes, best it can:
 // if data is Error type, returns (status, {status: status, message: message})
 // if other error, returns (500, []byte(err.Error()))
-func errorOrOtherToBytes(err error) (int, []byte) {
+func errorOrOtherToBytes(err error) (int, []byte, contentType) {
 	statusCode := 500
 	realData := []byte(err.Error())
 
-	// first, check if it's response type, and unpack it for further processing
+	// first, check if it's Error type, and unpack it for further processing
 	if e, ok := err.(Error); ok {
 		statusCode = e.Status
 		errJSON, marshalErr := json.Marshal(e)
 		if marshalErr != nil {
-			return statusCode, realData
+			return statusCode, realData, contentTypeTextPlain
 		}
 
-		return statusCode, errJSON
+		return statusCode, errJSON, contentTypeJSON
 	}
 
-	return statusCode, realData
+	return statusCode, realData, contentTypeTextPlain
 }

--- a/vk/middleware.go
+++ b/vk/middleware.go
@@ -9,12 +9,40 @@ import (
 // Middleware represents a handler that runs on a request before reaching its handler
 type Middleware func(*http.Request, *Ctx) error
 
-// ContentTypeMiddleware allows the content-type to be set for a handler or group
+// ContentTypeMiddleware allows the content-type to be set
 func ContentTypeMiddleware(contentType string) Middleware {
 	return func(r *http.Request, ctx *Ctx) error {
-		ctx.Headers.Add("Content-Type", contentType)
+		ctx.Headers.Set(contentTypeHeaderKey, contentType)
 
 		return nil
+	}
+}
+
+// CORSMiddleware enables CORS with the given domain for a route
+// pass "*" to allow all domains, or empty string to allow none
+func CORSMiddleware(domain string) Middleware {
+	return func(r *http.Request, ctx *Ctx) error {
+		enableCors(ctx, domain)
+
+		return nil
+	}
+}
+
+// CORSHandler enables CORS for a route
+// pass "*" to allow all domains, or empty string to allow none
+func CORSHandler(domain string) HandlerFunc {
+	return func(r *http.Request, ctx *Ctx) (interface{}, error) {
+		enableCors(ctx, domain)
+
+		return nil, nil
+	}
+}
+
+func enableCors(ctx *Ctx, domain string) {
+	if domain != "" {
+		ctx.Headers.Set("Access-Control-Allow-Origin", domain)
+		ctx.Headers.Set("X-Requested-With", "XMLHttpRequest")
+		ctx.Headers.Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, cache-control")
 	}
 }
 

--- a/vk/router.go
+++ b/vk/router.go
@@ -147,12 +147,12 @@ func (rt *Router) with(inner HandlerFunc) httprouter.Handle {
 		headerCType := w.Header().Get(contentTypeHeaderKey)
 		shouldSetCType := headerCType == ""
 
-		rt.getLogger().Info("post-handler contenttype:", string(headerCType))
+		rt.getLogger().Debug("post-handler contenttype:", string(headerCType))
 
 		// if no contentType was set in the middleware chain,
 		// then set it here based on the type detected
 		if shouldSetCType {
-			rt.getLogger().Info("setting auto-detected contenttype:", string(detectedCType))
+			rt.getLogger().Debug("setting auto-detected contenttype:", string(detectedCType))
 			w.Header().Set(contentTypeHeaderKey, string(detectedCType))
 		}
 

--- a/vk/router.go
+++ b/vk/router.go
@@ -8,6 +8,11 @@ import (
 	"github.com/suborbital/vektor/vlog"
 )
 
+const contentTypeHeaderKey = "Content-Type"
+
+// used internally to convey content types
+type contentType string
+
 // HandlerFunc is the vk version of http.HandlerFunc
 // instead of exposing the ResponseWriter, the function instead returns
 // an object and an error, which are handled as described in `With` below
@@ -126,14 +131,29 @@ func (rt *Router) with(inner HandlerFunc) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		var status int
 		var body []byte
+		var detectedCType contentType
 
 		ctx := NewCtx(rt.getLogger(), params, w.Header())
 
 		resp, err := inner(r, ctx)
 		if err != nil {
-			status, body = errorOrOtherToBytes(err)
+			status, body, detectedCType = errorOrOtherToBytes(err)
 		} else {
-			status, body = responseOrOtherToBytes(resp)
+			status, body, detectedCType = responseOrOtherToBytes(resp)
+		}
+
+		// check if anything in the handler chain set the content type
+		// header, and only use the auto-detected value if it wasn't
+		headerCType := w.Header().Get(contentTypeHeaderKey)
+		shouldSetCType := headerCType == ""
+
+		rt.getLogger().Info("post-handler contenttype:", string(headerCType))
+
+		// if no contentType was set in the middleware chain,
+		// then set it here based on the type detected
+		if shouldSetCType {
+			rt.getLogger().Info("setting auto-detected contenttype:", string(detectedCType))
+			w.Header().Set(contentTypeHeaderKey, string(detectedCType))
 		}
 
 		w.WriteHeader(status)

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -17,7 +17,7 @@ func main() {
 	server.POST("/f", HandleFound)
 	server.GET("/nf", HandleNotFound)
 
-	v1 := vk.Group("/v1", vk.ContentTypeMiddleware("application/json"), denyMiddleware, headerMiddleware)
+	v1 := vk.Group("/v1", denyMiddleware, headerMiddleware)
 	v1.GET("/me", HandleMe)
 
 	v2 := vk.Group("/v2")


### PR DESCRIPTION
Resolves https://github.com/suborbital/vektor/issues/12

The type returned by the HandlerFunc or Middleware will be used to detect what content type to set, unless one was set manually, in which case the existing value is respected.