### PR TITLE
revamp errors to use an interface and treat generic error as unsafe

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -172,7 +172,7 @@ func HandleDelete(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 
 `vk.Response` is an (optional) type that can be used to control the behaviour of the response, if desired. `vk.Respond(...)` returns a `vk.Response`.
 
-1. If the type is `vk.Response`, set the HTTP response code provided and process `Response.body` as follows. (If the type is NOT `vk.Response`, the status code is set to `200 OK`)
+1. If the type is `vk.Response`, set the HTTP status code provided and process `Response.body` as follows. (If the type is NOT `vk.Response`, the status code is set to `200 OK`)
 1. If the type is string, write the string (as UTF-8 bytes) to the response body.
 1. If the type is bytes, write them directly to the response body.
 1. If the type is a struct, attempt to marshal to JSON and write JSON bytes to the response body.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -136,7 +136,7 @@ Middleware in `vk` is designed to be easily composable, creating chains of behav
 
 ## Response types
 
-`vk` includes two types, `Response` and `Error` (with helper functions `vk.Respond` and `vk.Error`) that can be used to gain extra control over the response code and contents that you want to return:
+`vk` includes two types, `Response` and `Error` (with helper functions `vk.Respond(...)` and `vk.Err(...)`) that can be used to gain extra control over the response code and contents that you want to return:
 
 ```golang
 type createdResponse struct {
@@ -159,16 +159,18 @@ func HandleCreate(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 func HandleDelete(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 	// Oops, something went wrong
 
-	return nil, vk.Error(http.StatusConflict, "the user is already deleted") // responds with HTTP status 409 and body {"status": 409, "message": "the user is already deleted"}
+	return nil, vk.Err(http.StatusConflict, "the user is already deleted") // responds with HTTP status 409 and body {"status": 409, "message": "the user is already deleted"}
 }
 ```
-`vk.Respond` and `vk.Error` can be used with their shortcuts `vk.R` and `vk.E` if you like your code to be terse.
+`vk.Respond` and `vk.Err` can be used with their shortcuts `vk.R` and `vk.E` if you like your code to be terse.
 
 ## Response handling rules
 
 `vk` processes the `(interface{}, error)` returned by handler functions in a spcific way to ensure you always know how it will behave while still being able to use simple types in your code.
 
 ### Successful responses (i.e. the `interface{}` returned by handler functions):
+
+`vk.Response` is an (optional) type that can be used to control the behaviour of the response, if desired. `vk.Respond(...)` returns a `vk.Response`.
 
 1. If the type is `vk.Response`, set the HTTP response code provided and process `Response.body` as follows. (If the type is NOT `vk.Response`, the status code is set to `200 OK`)
 1. If the type is string, write the string (as UTF-8 bytes) to the response body.
@@ -187,17 +189,32 @@ Handler returns... | Status Code | Response body | Content-Type
 `return vk.R(http.StatusCreated, "created"), nil` | 201 Created | "created" (as UTF-8 bytes) | `text/plain`
 `return vk.R(http.StatusCreated, someStructInstance), nil` | 201 Created | [JSON respresentation of struct automatically marshalled by `vk`] | `application/json`
 
-### Failure responses (i.e. the `error` returned by handler functions):
+### Failure responses (i.e. the `error` returned by middleware or handler functions):
 
-1. If the type is `vk.Error`, set the HTTP response code provided and respond with JSON as follows: `{"status": $code, "message": $message}
-2. If the type is NOT `vk.Error`, set the HTTP status code to 500 and write `err.Error()` as UTF-8 bytes to the response body
+`vk.Error` is an interface that can be used to control the behaviour of error responses. `vk.ErrorResponse` is a concrete type that implements `vk.Error`. Any errors that do NOT implement `vk.Error` will be treated as potentially unsafe, and their contents will be logged but not returned to the caller. Use `vk.Wrap(...)` if you'd like to wrap an `error` in `vk.ErrorResponse`. `vk.Err` returns a `vk.Error`.
+
+`vk.Error` looks like this:
+```golang
+type Error interface {
+	Error() string // this ensures all Errors will also conform to the normal error interface
+
+	Message() string
+	Status() int
+}
+```
+
+Errors returned from middleware or `HandlerFunc`s are handled as follows:
+
+1. If the type is `vk.Error`, set the HTTP status code provided and respond with JSON as follows: `{"status": err.Status(), "message": err.Message()}`
+2. If the type is NOT `vk.Error`, log the potentially unsafe error contents, set the HTTP status code to 500, and respond with "Internal Server Error"
 
 Examples:
 
 Handler returns... | Status Code | Response body | Content-Type
 --- | --- | --- | ---
-`return nil, errors.New("failed to add user")` | 500 Internal Server Error | "failed to add user" (as UTF-8 bytes) | `text/plain`
-`retuen nil, vk.E(http.StatusForbidden, "not permitted to do this thing")` | 403 Forbidden | `{"status": 403, "message": "not permitted to do this thing"}` | `application/json`
+`return nil, errors.New("failed to add user")` | 500 Internal Server Error | "Internal Server Error" (as UTF-8 bytes) | `text/plain`
+`return nil, vk.E(http.StatusForbidden, "not permitted to do this thing")` | 403 Forbidden | `{"status": 403, "message": "not permitted to do this thing"}` | `application/json`
+`return nil, vk.Wrap(http.StatusApplicationError, err)` | 434 Application Error | `{"status": 434, "message": err.Error()}` | `application/json`
 
 ## What's to come?
 

--- a/vk/error.go
+++ b/vk/error.go
@@ -77,7 +77,7 @@ func errorOrOtherToBytes(l vlog.Logger, err error) (int, []byte, contentType) {
 		errJSON, marshalErr := json.Marshal(errResp)
 		if marshalErr != nil {
 			// any failure results in the generic response body being used
-			l.ErrorString("failed to marshal vk.Error:", marshalErr.Error(), "original error message:", err.Error())
+			l.ErrorString("failed to marshal vk.Error:", marshalErr.Error(), "original error:", err.Error())
 
 			return statusCode, genericErrorResponseBytes, contentTypeTextPlain
 		}
@@ -85,7 +85,7 @@ func errorOrOtherToBytes(l vlog.Logger, err error) (int, []byte, contentType) {
 		return statusCode, errJSON, contentTypeJSON
 	}
 
-	l.Warn("redacting potential unsafe error response, original error string:", err.Error())
+	l.Warn("redacting potential unsafe error response, original error:", err.Error())
 
 	return statusCode, genericErrorResponseBytes, contentTypeTextPlain
 }

--- a/vk/error.go
+++ b/vk/error.go
@@ -3,23 +3,45 @@ package vk
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/suborbital/vektor/vlog"
 )
 
-// Error represents an HTTP error
-type Error struct {
-	Status  int    `json:"status"`
-	Message string `json:"message"`
+// Error is an interface representing a failed request
+type Error interface {
+	Error() string // this ensures all Errors will also conform to the normal error interface
+
+	Message() string
+	Status() int
 }
 
-func (e Error) Error() string {
-	return fmt.Sprintf("%d: %s", e.Status, e.Message)
+// ErrorResponse is a concrete implementation of Error,
+// representing a failed HTTP request
+type ErrorResponse struct {
+	StatusCode  int    `json:"status"`
+	MessageText string `json:"message"`
+}
+
+// Error returns a full error string
+func (e *ErrorResponse) Error() string {
+	return fmt.Sprintf("%d: %s", e.StatusCode, e.MessageText)
+}
+
+// Status returns the error status code
+func (e *ErrorResponse) Status() int {
+	return e.StatusCode
+}
+
+// Message returns the error's message
+func (e *ErrorResponse) Message() string {
+	return e.MessageText
 }
 
 // Err returns an error with status and message
 func Err(status int, message string) Error {
-	e := Error{
-		Status:  status,
-		Message: message,
+	e := &ErrorResponse{
+		StatusCode:  status,
+		MessageText: message,
 	}
 
 	return e
@@ -30,23 +52,40 @@ func E(status int, message string) Error {
 	return Err(status, message)
 }
 
+// Wrap wraps an error in vk.Error
+func Wrap(status int, err error) Error {
+	return Err(status, err.Error())
+}
+
+var (
+	genericErrorResponseBytes = []byte("Internal Server Error")
+	genericErrorResponseCode  = 500
+)
+
 // converts _something_ into bytes, best it can:
 // if data is Error type, returns (status, {status: status, message: message})
 // if other error, returns (500, []byte(err.Error()))
-func errorOrOtherToBytes(err error) (int, []byte, contentType) {
-	statusCode := 500
-	realData := []byte(err.Error())
+func errorOrOtherToBytes(l vlog.Logger, err error) (int, []byte, contentType) {
+	statusCode := genericErrorResponseCode
 
-	// first, check if it's Error type, and unpack it for further processing
+	// first, check if it's vk.Error interface type, and unpack it for further processing
 	if e, ok := err.(Error); ok {
-		statusCode = e.Status
-		errJSON, marshalErr := json.Marshal(e)
+		statusCode = e.Status() // grab this in case anything fails
+
+		errResp := Err(e.Status(), e.Message()) // create a concrete instance that can be marshalled
+
+		errJSON, marshalErr := json.Marshal(errResp)
 		if marshalErr != nil {
-			return statusCode, realData, contentTypeTextPlain
+			// any failure results in the generic response body being used
+			l.ErrorString("failed to marshal vk.Error:", marshalErr.Error(), "original error message:", err.Error())
+
+			return statusCode, genericErrorResponseBytes, contentTypeTextPlain
 		}
 
 		return statusCode, errJSON, contentTypeJSON
 	}
 
-	return statusCode, realData, contentTypeTextPlain
+	l.Warn("redacting potential unsafe error response, original error string:", err.Error())
+
+	return statusCode, genericErrorResponseBytes, contentTypeTextPlain
 }

--- a/vk/response.go
+++ b/vk/response.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/suborbital/vektor/vlog"
 )
 
 // Response represents a non-error HTTP response
@@ -42,9 +43,9 @@ const (
 // if string, return (200, []byte(string))
 // if struct, return (200, json(struct))
 // otherwise, return (500, nil)
-func responseOrOtherToBytes(data interface{}) (int, []byte, contentType) {
+func responseOrOtherToBytes(l vlog.Logger, data interface{}) (int, []byte, contentType) {
 	if data == nil {
-		return http.StatusNoContent, []byte{}, contentTypeOctetStream
+		return http.StatusNoContent, []byte{}, contentTypeTextPlain
 	}
 
 	statusCode := http.StatusOK
@@ -67,7 +68,9 @@ func responseOrOtherToBytes(data interface{}) (int, []byte, contentType) {
 	// so JSON marshal it and return it
 	json, err := json.Marshal(realData)
 	if err != nil {
-		return 500, []byte(errors.Wrap(err, "failed to json Marshal response struct").Error()), contentTypeTextPlain // TODO: make this error reporting better
+		l.Error(errors.Wrap(err, "failed to Marshal response struct"))
+
+		return genericErrorResponseCode, []byte(genericErrorResponseBytes), contentTypeTextPlain
 	}
 
 	return statusCode, json, contentTypeJSON

--- a/vk/router.go
+++ b/vk/router.go
@@ -137,9 +137,9 @@ func (rt *Router) with(inner HandlerFunc) httprouter.Handle {
 
 		resp, err := inner(r, ctx)
 		if err != nil {
-			status, body, detectedCType = errorOrOtherToBytes(err)
+			status, body, detectedCType = errorOrOtherToBytes(rt.getLogger(), err)
 		} else {
-			status, body, detectedCType = responseOrOtherToBytes(resp)
+			status, body, detectedCType = responseOrOtherToBytes(rt.getLogger(), resp)
 		}
 
 		// check if anything in the handler chain set the content type

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -17,9 +17,11 @@ func main() {
 
 	v1 := vk.Group("/v1", denyMiddleware, headerMiddleware)
 	v1.GET("/me", HandleMe)
+	v1.GET("/me/hack", HandleMe)
 
 	v2 := vk.Group("/v2")
 	v2.GET("/you", HandleYou)
+	v2.GET("/mistake", HandleBadMistake)
 
 	api := vk.Group("/api")
 	api.AddGroup(v1)

--- a/vk/test/routes.go
+++ b/vk/test/routes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/suborbital/vektor/vk"
@@ -26,4 +27,9 @@ func HandleMe(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 // HandleYou handles You requests
 func HandleYou(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 	return vk.R(201, "created, I guess"), nil
+}
+
+// HandleBadMistake handles a bad mistake
+func HandleBadMistake(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
+	return nil, errors.New("this is a bad idea!!")
 }


### PR DESCRIPTION
`Error` becomes an interface, and the old type becomes `ErrorResponse`, which implements `Error`

Generic `error`s are now logged and their contents are NOT returned to the caller.

Resolves https://github.com/suborbital/vektor/issues/15