### PR TITLE
add HandleHTTP to router

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -216,6 +216,9 @@ Handler returns... | Status Code | Response body | Content-Type
 `return nil, vk.E(http.StatusForbidden, "not permitted to do this thing")` | 403 Forbidden | `{"status": 403, "message": "not permitted to do this thing"}` | `application/json`
 `return nil, vk.Wrap(http.StatusApplicationError, err)` | 434 Application Error | `{"status": 434, "message": err.Error()}` | `application/json`
 
+## Standard http.HandlerFunc
+`vk` can mount standard `http.HandlerFunc` handlers by mounting them with `server.HandleHTTP`. This is useful for mounting handler functions provided by third party libraries (such as Prometheus), but they are not able to take advantage of many `vk` features such as middleware or route groups currently.
+
 ## What's to come?
 
 `Vektor` is under active development. It intertwines closely with [Hive](https://github.com/suborbital/hive) to achieve Suborbital's goal of creating a framework for scalable web services. Hive and Vektor together can handle very large scale systems, and will be further integrated together to enable FaaS, WASM-based web service logic, and vastly improved developer experience and productivity.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -217,7 +217,7 @@ Handler returns... | Status Code | Response body | Content-Type
 `return nil, vk.Wrap(http.StatusApplicationError, err)` | 434 Application Error | `{"status": 434, "message": err.Error()}` | `application/json`
 
 ## Standard http.HandlerFunc
-`vk` can mount standard `http.HandlerFunc` handlers by mounting them with `server.HandleHTTP`. This is useful for mounting handler functions provided by third party libraries (such as Prometheus), but they are not able to take advantage of many `vk` features such as middleware or route groups currently.
+`vk` can use standard `http.HandlerFunc` handlers by mounting them with `server.HandleHTTP`. This is useful for mounting handler functions provided by third party libraries (such as Prometheus), but they are not able to take advantage of many `vk` features such as middleware or route groups currently.
 
 ## What's to come?
 

--- a/vk/router.go
+++ b/vk/router.go
@@ -96,6 +96,13 @@ func (rt *Router) Handle(method, path string, handler HandlerFunc) {
 	rt.root.Handle(method, path, handler)
 }
 
+// HandleHTTP allows vk to handle a standard http.HandlerFunc
+func (rt *Router) HandleHTTP(method, path string, handler http.HandlerFunc) {
+	rt.hrouter.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+		handler(w, r)
+	})
+}
+
 // AddGroup adds a group to the router's root group,
 // which is mounted to the server upon Start()
 func (rt *Router) AddGroup(group *RouteGroup) {

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/suborbital/vektor/vk"
 )
@@ -28,6 +29,8 @@ func main() {
 	api.AddGroup(v2)
 
 	server.AddGroup(api)
+
+	server.HandleHTTP(http.MethodGet, "/http", HandleHTTP)
 
 	if err := server.Start(); err != nil {
 		log.Fatal(err)

--- a/vk/test/routes.go
+++ b/vk/test/routes.go
@@ -33,3 +33,8 @@ func HandleYou(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 func HandleBadMistake(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 	return nil, errors.New("this is a bad idea!!")
 }
+
+// HandleHTTP tests HTTP handlers
+func HandleHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
This PR allows standard `http.HandlerFunc` to be mounted to the vk router.