### PR TITLE
Add support for Afterware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@
 *.out
 
 .bin
-
-test

--- a/vk/router.go
+++ b/vk/router.go
@@ -32,7 +32,7 @@ func routerWithOptions(options Options, middleware ...Middleware) *Router {
 
 	r := &Router{
 		hrouter: httprouter.New(),
-		root:    Group("", middleware...),
+		root:    Group("").Before(middleware...),
 		getLogger: func() *vlog.Logger {
 			return options.Logger
 		},

--- a/vk/test/afterware.go
+++ b/vk/test/afterware.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/suborbital/vektor/vk"
+)
+
+func logAfter(r *http.Request, ctx *vk.Ctx) {
+	ctx.Log.Info("afterware log")
+}

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -27,11 +27,11 @@ func main() {
 	server.POST("/f", HandleFound)
 	server.GET("/nf", HandleNotFound)
 
-	v1 := vk.Group("/v1", denyMiddleware, headerMiddleware)
+	v1 := vk.Group("/v1").Before(denyMiddleware, headerMiddleware)
 	v1.GET("/me", HandleMe)
 	v1.GET("/me/hack", HandleMe)
 
-	v2 := vk.Group("/v2", setScopeMiddleware)
+	v2 := vk.Group("/v2").Before(setScopeMiddleware).After(logAfter)
 	v2.GET("/you", HandleYou)
 	v2.GET("/mistake", HandleBadMistake)
 


### PR DESCRIPTION
This PR adds `Afterware` support to route groups using the `After` method, and moves Middleware to a `Before` method which are both chain-able as they return their `RouteGroup` object, allowing you to do:

```golang
v1 := vk.Group("/v1").Before(someMiddleware).After(someAfterware)
```