### PR TITLE
VLog improvements, docs, response code logging, env prefix, and more!

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vektor consists of components that can be used to help you build your web apps a
 
 The `vk` component is central to Vektor. It helps to quickly build production-ready API services with Go. It includes secure-by-default settings such as built-in LetsEncrypt, lots of customizability, and helpers galore. It will soon integrate with Suborbital's Hive job scheduler to allow performing more complex and performance-oriented work. `vk` enables minimal-boilerplate servers with an intuitive wrapper around the most performant HTTP router, [httprouter](https://github.com/julienschmidt/httprouter).
 
-**Vektor Logger (alpha)**
+**Vektor Logger (beta)**
 
 `vlog` is a low-effort logging package that will allow for structured or text-based logging, that will easily work with popular third-party logging systems.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,7 +16,7 @@ func HandlePing(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 	return "pong", nil
 }
 ```
-Those are the basics, but Vektor is capable of scaling up to serve powerful production workloads, using its full framework of API-oriented features.
+Those are the basics, but Vektor is capable of scaling up to serve powerful production workloads, using its full suite of API-oriented features.
 
 # Set up `vk`
 
@@ -232,4 +232,4 @@ Handler returns... | Status Code | Response body | Content-Type
 
 ## What's to come?
 
-`Vektor` is under active development. It intertwines closely with [Hive](https://github.com/suborbital/hive) to achieve Suborbital's goal of creating a framework for scalable web services. Hive and Vektor together can handle very large scale systems, and will be further integrated together to enable FaaS, WASM-based web service logic, and vastly improved developer experience and productivity.
+`Vektor` is under active development. It intertwines closely with [Hive](https://github.com/suborbital/hive) and [Grav](https://github.com/suborbital/grav) to achieve Suborbital's goal of creating a platform for building scalable web services. Hive and Vektor together can handle very large scale systems, and will be further integrated together to enable FaaS, WASM-based web service logic, and vastly improved developer experience and productivity.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -35,12 +35,15 @@ The included `OptionsModifiers` are:
 
 Option | Description | ENV key
 --- | --- | ---
-UseDomain(domain string) | Enable LetsEncrypt support with the provided domain name (will serve on :80 and :443 for challenge server and API server). LetsEncrypt is disabled by default. | `DOMAIN`
-UseInsecureHTTP(port int) | Choose the port on which to serve requests. Default is port 443. | `USE_HTTP_PORT`
-UseLogger(logger vlog.Logger) | Set the logger object to be used, which conforms to the `vlog.Logger` interface. The logger is used internally by `vk` and is available to all handler functions via the `ctx` object. `vlog.DefaultLogger` is used by default. | N/A
-UseAppName(name string) | When the application starts, `name` will be logged. Empty by default. | `APP_NAME`
+UseDomain(domain string) | Enable LetsEncrypt support with the provided domain name (will serve on :80 and :443 for challenge server and API server). LetsEncrypt is disabled by default. | `VK_DOMAIN`
+UseInsecureHTTP(port int) | Choose the port on which to serve requests. Default is port 443. | `VK_HTTP_PORT`
+UseAppName(name string) | When the application starts, `name` will be logged. Empty by default. | `VK_APP_NAME`
+UseEnvPrefix(prefix string) | Use `prefix` instead of `VK` for environment variables, for example `APP_HTTP_PORT` instead of `VK_HTTP_PORT`. | N/A
+UseLogger(logger *vlog.Logger) | Set the logger object to be used. The logger is used internally by `vk` and is available to all handler functions via the `ctx` object. `vlog.Default` is used by default. | N/A
 
-Each of the options can be set using the modifier function, or by setting the associated environment variable. The modifier function will override the env var.
+Each of the options can be set using the modifier function, or by setting the associated environment variable. The environment variable will override the modifier function.
+
+> Note the use of `UseEnvPrefix` if you would prefer to use something other than `VK` for your environment variables!
 
 ## Handler functions
 

--- a/vk/modifiers.go
+++ b/vk/modifiers.go
@@ -42,3 +42,12 @@ func UseAppName(name string) OptionsModifier {
 		return o
 	}
 }
+
+// UseEnvPrefix uses the provided env prefix (default VK) when looking up other options such as `VK_HTTP_PORT`
+func UseEnvPrefix(prefix string) OptionsModifier {
+	return func(o Options) Options {
+		o.EnvPrefix = prefix
+
+		return o
+	}
+}

--- a/vk/options.go
+++ b/vk/options.go
@@ -27,13 +27,15 @@ func (o Options) ShouldUseHTTP() (bool, string) {
 	return false, ""
 }
 
-func defaultOptions(prefix string) Options {
-	var o Options
+// finalize "locks in" the options by overriding any existing options with the version from the environment, and setting the default logger if needed
+func (o Options) finalize(prefix string) Options {
 	if err := envconfig.ProcessWith(context.Background(), &o, envconfig.PrefixLookuper(prefix, envconfig.OsLookuper())); err != nil {
 		log.Fatal(err)
 	}
 
-	o.Logger = vlog.Default()
+	if o.Logger == nil {
+		o.Logger = vlog.Default()
+	}
 
 	return o
 }

--- a/vk/options.go
+++ b/vk/options.go
@@ -11,10 +11,11 @@ import (
 
 // Options are the available options for Server
 type Options struct {
-	AppName  string `env:"APP_NAME"`
-	Domain   string `env:"DOMAIN"`
-	HTTPPort int    `env:"USE_HTTP_PORT"`
-	Logger   *vlog.Logger
+	AppName   string `env:"_APP_NAME"`
+	Domain    string `env:"_DOMAIN"`
+	HTTPPort  int    `env:"_HTTP_PORT"`
+	EnvPrefix string `env:"-"`
+	Logger    *vlog.Logger
 }
 
 // ShouldUseHTTP returns true and a port string if the option is enabled
@@ -26,9 +27,9 @@ func (o Options) ShouldUseHTTP() (bool, string) {
 	return false, ""
 }
 
-func defaultOptions() Options {
+func defaultOptions(prefix string) Options {
 	var o Options
-	if err := envconfig.Process(context.Background(), &o); err != nil {
+	if err := envconfig.ProcessWith(context.Background(), &o, envconfig.PrefixLookuper(prefix, envconfig.OsLookuper())); err != nil {
 		log.Fatal(err)
 	}
 

--- a/vk/server.go
+++ b/vk/server.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
+const defaultEnvPrefix = "VK"
+
 // Server represents a vektor API server
 type Server struct {
 	*Router
@@ -16,7 +18,19 @@ type Server struct {
 
 // New creates a new vektor API server
 func New(opts ...OptionsModifier) *Server {
-	options := defaultOptions()
+	fakeOpts := Options{}
+	// loop through the provided options on a fake object
+	// to see if an env prefix was set
+	for _, mod := range opts {
+		fakeOpts = mod(fakeOpts)
+	}
+
+	envPrefix := defaultEnvPrefix
+	if fakeOpts.EnvPrefix != "" {
+		envPrefix = fakeOpts.EnvPrefix
+	}
+
+	options := defaultOptions(envPrefix)
 
 	// loop through the provided options and apply the
 	// modifier function to the options object
@@ -47,7 +61,7 @@ func (s *Server) Start() error {
 	}
 
 	if useHTTP, _ := s.options.ShouldUseHTTP(); !useHTTP && s.options.Domain == "" {
-		s.options.Logger.ErrorString("DOMAIN and USE_HTTP_PORT are both unset, server will start up but will fail to acquire a certificate, reconfigure and restart")
+		s.options.Logger.ErrorString("domain and HTTP port options are both unset, server will start up but will fail to acquire a certificate, reconfigure and restart")
 	} else if s.options.Domain != "" {
 		s.options.Logger.Info("using domain", s.options.Domain)
 	}

--- a/vk/server.go
+++ b/vk/server.go
@@ -18,25 +18,19 @@ type Server struct {
 
 // New creates a new vektor API server
 func New(opts ...OptionsModifier) *Server {
-	fakeOpts := Options{}
-	// loop through the provided options on a fake object
-	// to see if an env prefix was set
-	for _, mod := range opts {
-		fakeOpts = mod(fakeOpts)
-	}
-
-	envPrefix := defaultEnvPrefix
-	if fakeOpts.EnvPrefix != "" {
-		envPrefix = fakeOpts.EnvPrefix
-	}
-
-	options := defaultOptions(envPrefix)
-
+	options := Options{}
 	// loop through the provided options and apply the
 	// modifier function to the options object
 	for _, mod := range opts {
 		options = mod(options)
 	}
+
+	envPrefix := defaultEnvPrefix
+	if options.EnvPrefix != "" {
+		envPrefix = options.EnvPrefix
+	}
+
+	options = options.finalize(envPrefix)
 
 	router := routerWithOptions(options)
 

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -14,13 +14,14 @@ type testMeta struct {
 
 func main() {
 	logger := vlog.Default(
-		vlog.Meta(testMeta{Version: "v0.1.1"}),
-		vlog.ToFile("/Users/cohix-pro/.op/logfile.log"),
+		vlog.AppMeta(testMeta{Version: "v0.1.1"}),
+		vlog.ToFile("/Users/cohix-16/.op/logfile.log"),
 	)
 
 	server := vk.New(
 		vk.UseAppName("vk tester"),
 		vk.UseLogger(logger),
+		vk.UseEnvPrefix("APP"),
 	)
 
 	server.GET("/f", HandleFound)

--- a/vlog/README.md
+++ b/vlog/README.md
@@ -1,0 +1,102 @@
+# VLog: Simple and Safe logging package
+
+`vlog` is the logging package for the Suborbital Development Platform. It is designed to have a minimal performance impact and promote logging safety.
+
+## The default instance
+For most users, using `vlog.Default()` is enough. This creates a `Logger` that logs to stdout, uses the `info` log level, and redacts non-string inputs. If you want to gain finer control over the logger, read on!
+
+## Using the logger
+The logger uses a simple API to get out of your way:
+```golang
+// ErrorString logs the input as an error
+func (v *Logger) ErrorString(msgs ...interface{}) {}
+
+// Error logs an error object
+func (v *Logger) Error(err error) {}
+
+// Warn logs the input as an warning
+func (v *Logger) Warn(msgs ...interface{}) {}
+
+// Info logs the input as an info message
+func (v *Logger) Info(msgs ...interface{}) {}
+
+// Debug logs the input as debug output
+func (v *Logger) Debug(msgs ...interface{}) {}
+
+// Trace logs a function name and returns a function to be deferred, logging the completion of a function
+func (v *Logger) Trace(fnName string) func() {}
+```
+Each method takes in a list of `interface{}` which are appended when logging. For example:
+```golang
+log.Info("user", user.Email, "completed signin")
+```
+Will print `(I) user info@example.com completed signup`. The `(I)` indicates the log level (info). How the logger processes the passed in objects is determined by the producer, which is discussed below.
+
+## Log levels
+The logger will automatically filter out anything higher than the configured level. For example, if the logger is configured for `LogLevelError`, then the higher levels such as Info, Debug, and Trace will not be logged. The available log level are as follows:
+```golang
+// LogLevelTrace and others represent log levels
+const (
+	LogLevelTrace = "trace" // 5
+	LogLevelDebug = "debug" // 4
+	LogLevelInfo  = "info"  // 3
+	LogLevelWarn  = "warn"  // 2
+	LogLevelError = "error" // 1
+)
+```
+
+### The trace level
+The `Trace` log method is special, in that it returns a function. This allows for easy function tracing:
+```golang
+func SomethingAwesome() {
+	defer log.Trace("SomethingAwesome")
+}
+```
+This will print something like:
+```
+(T) SomethingAwesome
+[...]
+(T) SomethingAwesome completed
+```
+
+## Logger options
+The default constructor and `vlog.New()` both take a set of `OptionModifier` parameters, which are functions that set the various available options. For example:
+```golang
+log := vlog.Default(
+		vlog.Level(vlog.LogLevelTrace)
+	)
+```
+Passing in options will allow you to tweak the behaviour of the logger. The available options are:
+```golang
+// Level sets the logging level to one of error, warn, info, debug, or trace
+func Level(level string) {}
+
+// ToFile sets the logger to open the file specified and write logs to it
+func ToFile(filepath string) {}
+
+// Prefix sets a prefix on all of the log messages
+func Prefix(prefix string) {}
+
+// AppMeta sets the meta object to be included with structured logs
+func AppMeta(meta interface{}) {}
+```
+> Note if `ToFile` is used, structured logs are written to the file and plain text logs are duplicated to stdout.
+
+## The Producer
+`vlog` uses an object called the `Producer` to process all log lines. `Producer` is an interface type, and its implementation is responsible for taking the input passed into each log method and converting it into a string for logging. The `Producer` that ships with `vlog` is called `defaultProducer`; it logs all strings, but redacts all other types it is given for safety. If logging of structs or other types is needed, it is reccomended that a custom `Producer` is created. Simply copy `defaultproducer.go`, add your own functionality, and pass it in to `vlog.New(producer, opts...)` to create your logger.
+
+## Structured logging
+Structured logs are core to vlog, and there are a number of features that make it useful. Things like the log level and timestamp are included by default, and `AppMeta` and `Scope` are two ways to make structured logs even more useful.
+
+An example of a structured log is as follows:
+```json
+{"log_message":"(I) serving on :443","timestamp":"2020-10-12T20:55:00.644217-04:00","level":3,"app":{"version":"v0.1.1"}}
+```
+
+### AppMeta
+`AppMeta` (configured using the `Meta()` OptionModifier when instantiating the logger) represents metadata about the running application. The configured meta will be included with every log message. This can be used to indicate the version of the currently running application, for example. The `AppMeta` is included in structured logs under the `app` JSON key. If the object set as AppMeta cannot be JSON marshalled, an error will occur.
+
+### Scope
+A `Logger` instance can create a "scoped" instance of itself, which is essentially a clone with a specific scope object attached. Scope can be useful to add a specific request ID to logs related to it, for instance. Calling `logger.CreateScoped(scope interface{})` on a `Logger` will return a new `Logger` that includes the provided object under the `scope` JSON key. If the object set as Scope cannot be JSON marshalled, an error will occur.
+
+A shortcut for setting scope on the logger with `vk` is the `ctx.UseScope()` method on the `vk.Ctx` type. This will automatically create a scoped logger, set it as the logger for that request, and make the scope object available for later use via the `ctx.Scope()` method. 

--- a/vlog/defaultproducer.go
+++ b/vlog/defaultproducer.go
@@ -2,14 +2,13 @@ package vlog
 
 import (
 	"fmt"
-	"strings"
 )
 
 type defaultProducer struct{}
 
 // ErrorString prints a string as an error
-func (d *defaultProducer) ErrorString(msgs ...string) string {
-	return fmt.Sprintf("(E) %s", strings.Join(msgs, " "))
+func (d *defaultProducer) ErrorString(msgs ...interface{}) string {
+	return fmt.Sprintf("(E) %s", redactAndJoinInterfaces(msgs...))
 }
 
 // Error prints a string as an error
@@ -18,18 +17,18 @@ func (d *defaultProducer) Error(err error) string {
 }
 
 // Warn prints a string as an warning
-func (d *defaultProducer) Warn(msgs ...string) string {
-	return fmt.Sprintf("(W) %s", strings.Join(msgs, " "))
+func (d *defaultProducer) Warn(msgs ...interface{}) string {
+	return fmt.Sprintf("(W) %s", redactAndJoinInterfaces(msgs...))
 }
 
 // Info prints a string as an info message
-func (d *defaultProducer) Info(msgs ...string) string {
-	return fmt.Sprintf("(I) %s", strings.Join(msgs, " "))
+func (d *defaultProducer) Info(msgs ...interface{}) string {
+	return fmt.Sprintf("(I) %s", redactAndJoinInterfaces(msgs...))
 }
 
 // Debug prints a string as debug output
-func (d *defaultProducer) Debug(msgs ...string) string {
-	return fmt.Sprintf("(D) %s", strings.Join(msgs, " "))
+func (d *defaultProducer) Debug(msgs ...interface{}) string {
+	return fmt.Sprintf("(D) %s", redactAndJoinInterfaces(msgs...))
 }
 
 // Trace prints a function name and returns a function to be deferred, logging the completion of a function
@@ -39,4 +38,20 @@ func (d *defaultProducer) Trace(fnName string) (string, func() string) {
 	}
 
 	return (fmt.Sprintf("(T) %s", fnName)), traceFunc
+}
+
+func redactAndJoinInterfaces(msgs ...interface{}) string {
+	msg := ""
+
+	for _, m := range msgs {
+		str, ok := m.(string)
+		if ok {
+			msg += fmt.Sprintf(" %s", str)
+		} else {
+			msg += fmt.Sprintf(" [redacted %T]", m)
+		}
+	}
+
+	// get rid of that first space
+	return msg[1:]
 }

--- a/vlog/options.go
+++ b/vlog/options.go
@@ -40,7 +40,6 @@ func Level(level string) OptionsModifier {
 }
 
 // ToFile sets the logger to open the file specified and write logs to it
-// be a good citizen and call Close() on the logger before the program ends
 func ToFile(filepath string) OptionsModifier {
 	return func(opt Options) Options {
 		opt.filepath = filepath
@@ -58,8 +57,8 @@ func Prefix(prefix string) OptionsModifier {
 	}
 }
 
-// Meta sets the meta object to be included with structured logs
-func Meta(meta interface{}) OptionsModifier {
+// AppMeta sets the AppMeta object to be included with structured logs
+func AppMeta(meta interface{}) OptionsModifier {
 	return func(opt Options) Options {
 		opt.appMeta = meta
 

--- a/vlog/vlog.go
+++ b/vlog/vlog.go
@@ -10,12 +10,12 @@ import (
 
 // Producer represents an object that is considered a producer of messages
 type Producer interface {
-	ErrorString(...string) string         // Logs an error string
+	ErrorString(...interface{}) string    // Logs an error string
 	Error(error) string                   // Logs an error obj
-	Warn(...string) string                // Logs a warning
-	Info(...string) string                // Logs information
-	Debug(...string) string               // Logs debug information
-	Trace(string) (string, func() string) // Logs a function call and returns a function to be deferred, indicating the end of the function
+	Warn(...interface{}) string           // Logs a warning
+	Info(...interface{}) string           // Logs information
+	Debug(...interface{}) string          // Logs debug information
+	Trace(string) (string, func() string) // Logs a function name and returns a function to be deferred, indicating the end of the function
 }
 
 // Logger is the main logger object, responsible for taking input from the
@@ -71,7 +71,7 @@ func (v *Logger) CreateScoped(scope interface{}) *Logger {
 }
 
 // ErrorString logs a string as an error
-func (v *Logger) ErrorString(msgs ...string) {
+func (v *Logger) ErrorString(msgs ...interface{}) {
 	msg := v.producer.ErrorString(msgs...)
 
 	v.log(msg, v.scope, 1)
@@ -85,21 +85,21 @@ func (v *Logger) Error(err error) {
 }
 
 // Warn logs a string as an warning
-func (v *Logger) Warn(msgs ...string) {
+func (v *Logger) Warn(msgs ...interface{}) {
 	msg := v.producer.Warn(msgs...)
 
 	v.log(msg, v.scope, 2)
 }
 
 // Info logs a string as an info message
-func (v *Logger) Info(msgs ...string) {
+func (v *Logger) Info(msgs ...interface{}) {
 	msg := v.producer.Info(msgs...)
 
 	v.log(msg, v.scope, 3)
 }
 
 // Debug logs a string as debug output
-func (v *Logger) Debug(msgs ...string) {
+func (v *Logger) Debug(msgs ...interface{}) {
 	msg := v.producer.Debug(msgs...)
 
 	v.log(msg, v.scope, 4)
@@ -121,6 +121,10 @@ func (v *Logger) Trace(fnName string) func() {
 func (v *Logger) log(message string, scope interface{}, level int) {
 	if level > v.opts.level {
 		return
+	}
+
+	if v.opts.prefix != "" {
+		message = v.opts.prefix + " " + message
 	}
 
 	// send the raw message to the console


### PR DESCRIPTION
This PR does a number of loosely related things.

- Adds `vlog` docs
- Updates `vlog` to take `...interface{}` in most cases instead of `...string`
- Updates `defaultProducer` to process the above
- Add response completion and status code logging
- Use the `ctx` logger instead of the default server logger to log request debug and info (which preserves any scope)
- Add the `UseEnvPrefix` OptionModifier to set the env prefix on `vk` options
- Simplify the `vk` env options to all have a common prefix (`VK` unless set using the above)
- Updated docs related to the above
- Swapped the logic around so that env vars override OptionModifiers