### PR TITLE
Improve loading options from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 *.out
 
 .bin
+
+# Test binary
+test

--- a/vk/modifiers.go
+++ b/vk/modifiers.go
@@ -5,49 +5,39 @@ import (
 )
 
 // OptionsModifier takes an options struct and returns a modified Options struct
-type OptionsModifier func(Options) Options
+type OptionsModifier func(*Options)
 
 // UseDomain sets the server to use a particular domain for TLS
 func UseDomain(domain string) OptionsModifier {
-	return func(o Options) Options {
+	return func(o *Options) {
 		o.Domain = domain
-
-		return o
 	}
 }
 
 // UseInsecureHTTP sets the server to serve on HTTP
 func UseInsecureHTTP(port int) OptionsModifier {
-	return func(o Options) Options {
+	return func(o *Options) {
 		o.HTTPPort = port
-
-		return o
 	}
 }
 
 // UseLogger allows a custom logger to be used
 func UseLogger(logger *vlog.Logger) OptionsModifier {
-	return func(o Options) Options {
+	return func(o *Options) {
 		o.Logger = logger
-
-		return o
 	}
 }
 
 // UseAppName allows an app name to be set (for vanity only, really....)
 func UseAppName(name string) OptionsModifier {
-	return func(o Options) Options {
+	return func(o *Options) {
 		o.AppName = name
-
-		return o
 	}
 }
 
 // UseEnvPrefix uses the provided env prefix (default VK) when looking up other options such as `VK_HTTP_PORT`
 func UseEnvPrefix(prefix string) OptionsModifier {
-	return func(o Options) Options {
+	return func(o *Options) {
 		o.EnvPrefix = prefix
-
-		return o
 	}
 }

--- a/vk/options.go
+++ b/vk/options.go
@@ -18,8 +18,26 @@ type Options struct {
 	Logger    *vlog.Logger
 }
 
+func newOptsWithModifiers(mods ...OptionsModifier) *Options {
+	options := &Options{}
+	// loop through the provided options and apply the
+	// modifier function to the options object
+	for _, mod := range mods {
+		mod(options)
+	}
+
+	envPrefix := defaultEnvPrefix
+	if options.EnvPrefix != "" {
+		envPrefix = options.EnvPrefix
+	}
+
+	options.finalize(envPrefix)
+
+	return options
+}
+
 // ShouldUseHTTP returns true and a port string if the option is enabled
-func (o Options) ShouldUseHTTP() (bool, string) {
+func (o *Options) ShouldUseHTTP() (bool, string) {
 	if o.HTTPPort != 0 {
 		return true, fmt.Sprintf(":%d", o.HTTPPort)
 	}
@@ -28,14 +46,29 @@ func (o Options) ShouldUseHTTP() (bool, string) {
 }
 
 // finalize "locks in" the options by overriding any existing options with the version from the environment, and setting the default logger if needed
-func (o Options) finalize(prefix string) Options {
-	if err := envconfig.ProcessWith(context.Background(), &o, envconfig.PrefixLookuper(prefix, envconfig.OsLookuper())); err != nil {
+func (o *Options) finalize(prefix string) {
+	envOpts := Options{}
+	if err := envconfig.ProcessWith(context.Background(), &envOpts, envconfig.PrefixLookuper(prefix, envconfig.OsLookuper())); err != nil {
 		log.Fatal(err)
 	}
+
+	o.replaceFieldsIfNeeded(&envOpts)
 
 	if o.Logger == nil {
 		o.Logger = vlog.Default()
 	}
+}
 
-	return o
+func (o *Options) replaceFieldsIfNeeded(replacement *Options) {
+	if replacement.AppName != "" {
+		o.AppName = replacement.AppName
+	}
+
+	if replacement.Domain != "" {
+		o.Domain = replacement.Domain
+	}
+
+	if replacement.HTTPPort != 0 {
+		o.HTTPPort = replacement.HTTPPort
+	}
 }

--- a/vk/router.go
+++ b/vk/router.go
@@ -26,7 +26,7 @@ type Router struct {
 }
 
 // routerWithOptions returns a router with the specified options and optional middleware on the root route group
-func routerWithOptions(options Options, middleware ...Middleware) *Router {
+func routerWithOptions(options *Options, middleware ...Middleware) *Router {
 	// add the logger middleware first
 	middleware = append([]Middleware{loggerMiddleware(options.Logger)}, middleware...)
 

--- a/vk/server.go
+++ b/vk/server.go
@@ -13,24 +13,12 @@ const defaultEnvPrefix = "VK"
 type Server struct {
 	*Router
 	server  *http.Server
-	options Options
+	options *Options
 }
 
 // New creates a new vektor API server
 func New(opts ...OptionsModifier) *Server {
-	options := Options{}
-	// loop through the provided options and apply the
-	// modifier function to the options object
-	for _, mod := range opts {
-		options = mod(options)
-	}
-
-	envPrefix := defaultEnvPrefix
-	if options.EnvPrefix != "" {
-		envPrefix = options.EnvPrefix
-	}
-
-	options = options.finalize(envPrefix)
+	options := newOptsWithModifiers(opts...)
 
 	router := routerWithOptions(options)
 
@@ -69,7 +57,7 @@ func (s *Server) Start() error {
 	return s.server.ListenAndServeTLS("", "")
 }
 
-func createGoServer(options Options, handler http.Handler) *http.Server {
+func createGoServer(options *Options, handler http.Handler) *http.Server {
 	if useHTTP, portString := options.ShouldUseHTTP(); useHTTP {
 		return goHTTPServerWithPort(portString, handler)
 	}

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -22,6 +22,7 @@ func main() {
 		vk.UseAppName("vk tester"),
 		vk.UseLogger(logger),
 		vk.UseEnvPrefix("APP"),
+		vk.UseInsecureHTTP(8080),
 	)
 
 	server.GET("/f", HandleFound)


### PR DESCRIPTION
This improves the bootstrapping of `vk`'s server options to overwrite code-provided optionModifiers with env-provided options, even if the option was set in code.