### PR TITLE
Improvements to afterware and request scope

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15.7
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory
@@ -21,7 +21,7 @@ jobs:
         go get -v -t -d ./...
 
     - name: Build
-      run: make build/vk/test
+      run: make vk/tester
     
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,5 @@ test:
 
 deps:
 	go get -u -d ./...
+
+.PHONY: vk/tester vk/tester/run test deps

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
-build/vk/test:
+vk/tester:
 	GO111MODULE=on go build ./vk/test
 
-run/vk/test: build/vk/test
+vk/tester/run: vk/tester
 	./test
 
 test:

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,7 +132,7 @@ v1.GET("/events", HandleEventsV1)
 ```
 This example shows a group created with three middleware. The first adds the `Content-Type` response header (and is included with `vk`), the second and third are the examples from above. When the group is mounted to the server, the chain of middleware are put in place, and are run before the registered handler. When groups are nested, the middleware from the parent group are run before the middleware of any child groups. In the example of nested groups above, any middleware set on the `apiGroup` groups would run before any middleware set on the `v1` or `v2` groups.
 
-Afterware is similar, but is run _after_ the request handler. Who knew! Afterware cannot modify response body or status code, but can modify response headers using the `ctx` object. Here's an example:
+Afterware is similar, but is run _after_ the request handler. Who knew! Afterware cannot modify response body or status code, but can modify response headers using the `ctx` object. Afterware will **always run**, even if something earlier in the request chain fails. Here's an example:
 
 ```golang
 func logAfter(r *http.Request, ctx *vk.Ctx) {
@@ -238,11 +238,11 @@ Each request handler is passed a `vk.Ctx` object, which is a context object for 
 
 `Ctx` includes a standard Go `context.Context` which can be used as a pseudo key/value store using `ctx.Set()` and `ctx.Get()`. This allows passing things into request handlers such as database connections or other persistent objects. Middleware and Afterware can access the `Ctx` to modify it, or access data from it.
 
-The server's configured `vlog.Logger` object is included (`ctx.Log`) for logging within request handlers, and a shortcut for setting the logger's scope for the current request exists with `ctx.UseScope(...)`. You can learn about scope in [the vlog docs](../vlog/README.md).
+The server's configured `vlog.Logger` object is included (`ctx.Log`) for logging within request handlers, and a shortcut for setting the logger's scope for the current request exists with `ctx.UseScope(...)`. You can learn about scope in [the vlog docs](../vlog/README.md). A default scope will always be set with the request ID included.
 
 Accessing the URL params for the request (such as `/users/:uuid`) is done with `ctx.Params`, and `ctx.RespHeaders` can be used to set response headers if needed.
 
-`Ctx` can also be used to easily get a request ID, with `ctx.RequestID()`. The Request ID is generated and cached on the object, and so calling it multiple times will return the same value. If you prefer to set your own Request ID, `ctx.UseRequestID()` will do the trick.
+`Ctx` can also be used to easily get a request ID, with `ctx.RequestID()`. The Request ID is generated and cached on the object, and so calling it multiple times will return the same value. If you prefer to set your own Request ID, `ctx.UseRequestID()` will do the trick, however it will mean the first log message for the request will have a different ID as it uses the default ID generated for the `ctx`.
 
 ## What's to come?
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/suborbital/vektor
 
-go 1.13
+go 1.16
 
 require (
 	github.com/google/uuid v1.1.2

--- a/vk/router.go
+++ b/vk/router.go
@@ -25,10 +25,14 @@ type Router struct {
 	getLogger func() *vlog.Logger
 }
 
+type defaultScope struct {
+	RequestID string `json:"request_id"`
+}
+
 // routerWithOptions returns a router with the specified options and optional middleware on the root route group
 func routerWithOptions(options *Options, middleware ...Middleware) *Router {
 	// add the logger middleware first
-	middleware = append([]Middleware{loggerMiddleware(options.Logger)}, middleware...)
+	middleware = append([]Middleware{loggerMiddleware()}, middleware...)
 
 	r := &Router{
 		hrouter: httprouter.New(),
@@ -144,6 +148,7 @@ func (rt *Router) with(inner HandlerFunc) httprouter.Handle {
 		// (and use the ctx.Log for all remaining logging
 		// in case a scope was set on it)
 		ctx := NewCtx(rt.getLogger(), params, w.Header())
+		ctx.UseScope(defaultScope{ctx.RequestID()})
 
 		resp, err := inner(r, ctx)
 		if err != nil {

--- a/vk/test/middleware.go
+++ b/vk/test/middleware.go
@@ -8,12 +8,14 @@ import (
 )
 
 type reqScope struct {
-	ReqID string `json:"req_id"`
+	ReqID  string `json:"req_id"`
+	Foobar string `json:"foobar"`
 }
 
 func setScopeMiddleware(r *http.Request, ctx *vk.Ctx) error {
 	scope := reqScope{
-		ReqID: "asdfghj",
+		ReqID:  ctx.RequestID(),
+		Foobar: "barbaz",
 	}
 
 	ctx.UseScope(scope)


### PR DESCRIPTION
This PR makes two changes:

1) Afterware will always run, even if something earlier in the request chain fails

2) An object with `request_id` will always be set on the `ctx` so that the request ID gets logged even on the build-in logger middleware that announces the request. The same request ID will be returned by `ctx.RequestID`, so you can use it to build custom scope objects if needed.

It also updates the default Go version to 1.16