### PR TITLE
Allow configuring VLog with environment variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ UseDomain(domain string) | Enable LetsEncrypt support with the provided domain n
 UseInsecureHTTP(port int) | Choose the port on which to serve requests. Default is port 443. | `VK_HTTP_PORT`
 UseAppName(name string) | When the application starts, `name` will be logged. Empty by default. | `VK_APP_NAME`
 UseEnvPrefix(prefix string) | Use `prefix` instead of `VK` for environment variables, for example `APP_HTTP_PORT` instead of `VK_HTTP_PORT`. | N/A
-UseLogger(logger *vlog.Logger) | Set the logger object to be used. The logger is used internally by `vk` and is available to all handler functions via the `ctx` object. `vlog.Default` is used by default. | N/A
+UseLogger(logger *vlog.Logger) | Set the logger object to be used. The logger is used internally by `vk` and is available to all handler functions via the `ctx` object. If this option is not passed, `vlog.Default` is used, and its environment variable prefix set to the same as vk's. (`VK` by default). | N/A
 
 Each of the options can be set using the modifier function, or by setting the associated environment variable. The environment variable will override the modifier function.
 

--- a/vk/test/main.go
+++ b/vk/test/main.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/suborbital/vektor/vk"
-	"github.com/suborbital/vektor/vlog"
 )
 
 type testMeta struct {
@@ -13,15 +12,8 @@ type testMeta struct {
 }
 
 func main() {
-	logger := vlog.Default(
-		vlog.Level(vlog.LogLevelTrace),
-		vlog.AppMeta(testMeta{Version: "v0.1.1"}),
-		vlog.ToFile("/Users/cohix-16/.op/logfile.log"),
-	)
-
 	server := vk.New(
 		vk.UseAppName("vk tester"),
-		vk.UseLogger(logger),
 		vk.UseEnvPrefix("APP"),
 		vk.UseInsecureHTTP(8080),
 	)

--- a/vk/test/middleware.go
+++ b/vk/test/middleware.go
@@ -26,6 +26,7 @@ func setScopeMiddleware(r *http.Request, ctx *vk.Ctx) error {
 func denyMiddleware(r *http.Request, ctx *vk.Ctx) error {
 	if strings.Contains(r.URL.Path, "hack") {
 		ctx.Log.ErrorString("HACKER!!")
+		ctx.Log.Debug("but maybe they're nice")
 
 		return vk.E(403, "begone, hacker")
 	}

--- a/vlog/README.md
+++ b/vlog/README.md
@@ -68,16 +68,19 @@ log := vlog.Default(
 ```
 Passing in options will allow you to tweak the behaviour of the logger. The available options are:
 ```golang
-// Level sets the logging level to one of error, warn, info, debug, or trace
+// Level sets the logging level to one of error, warn, info, debug, or trace (VLOG_LOG_LEVEL env var)
 func Level(level string) {}
 
-// ToFile sets the logger to open the file specified and write logs to it
+// ToFile sets the logger to open the file specified and write logs to it (VLOG_LOG_FILE env var)
 func ToFile(filepath string) {}
 
-// Prefix sets a prefix on all of the log messages
-func Prefix(prefix string) {}
+// LogPrefix sets a prefix on all of the log messages (VLOG_LOG_PREFIX env var)
+func LogPrefix(prefix string) {}
 
-// AppMeta sets the meta object to be included with structured logs
+// EnvPrefix sets the prefix to be used for environment variable settings (replaces VLOG with prefix in env var keys above)
+func EnvPrefix(prefix string) {}
+
+// AppMeta sets the meta object to be included with structured logs (not configurable from env vars)
 func AppMeta(meta interface{}) {}
 ```
 > Note if `ToFile` is used, structured logs are written to the file and plain text logs are duplicated to stdout.

--- a/vlog/vlog.go
+++ b/vlog/vlog.go
@@ -23,7 +23,7 @@ type Producer interface {
 type Logger struct {
 	producer Producer
 	scope    interface{}
-	opts     Options
+	opts     *Options
 	output   io.Writer
 	lock     *sync.Mutex
 }
@@ -125,12 +125,12 @@ func (v *Logger) Trace(fnName string) func() {
 }
 
 func (v *Logger) log(message string, scope interface{}, level int) {
-	if level > v.opts.level {
+	if level > v.opts.Level {
 		return
 	}
 
-	if v.opts.prefix != "" {
-		message = v.opts.prefix + " " + message
+	if v.opts.LogPrefix != "" {
+		message = v.opts.LogPrefix + " " + message
 	}
 
 	// send the raw message to the console
@@ -148,7 +148,7 @@ func (v *Logger) log(message string, scope interface{}, level int) {
 		LogMessage: message,
 		Timestamp:  time.Now(),
 		Level:      level,
-		AppMeta:    v.opts.appMeta,
+		AppMeta:    v.opts.AppMeta,
 		ScopeMeta:  scope,
 	}
 
@@ -166,11 +166,11 @@ func (v *Logger) log(message string, scope interface{}, level int) {
 
 }
 
-func outputForOptions(opts Options) (io.Writer, error) {
+func outputForOptions(opts *Options) (io.Writer, error) {
 	var output io.Writer
 
-	if opts.filepath != "" {
-		file, err := os.OpenFile(opts.filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	if opts.Filepath != "" {
+		file, err := os.OpenFile(opts.Filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds env vars to control VLog:

`VLOG_LOG_LEVEL = {trace|debug|info|warn|error}`
`VLOG_LOG_FILE`
`VLOG_LOG_PREFIX`

The env var prefix can be modified by passing the `vlog.EnvPrefix` option to the contructor, for example if you want the env vars to be `APP_LOG_LEVEL`.

If no custom logger is set for a VK server instance, the default logger used will inherit the same env prefix as the server ('VK' by default)