### PR TITLE
Add TLS config and port options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ The included `OptionsModifiers` are:
 Option | Description | ENV key
 --- | --- | ---
 UseDomain(domain string) | Enable LetsEncrypt support with the provided domain name (will serve on :80 and :443 for challenge server and API server). LetsEncrypt is disabled by default. | `VK_DOMAIN`
+UseTLSConfig(config *tls.Config) | Enable TLS and use the provided TLS config to serve HTTPS. This will override the `domain` option. | N/A
+UseTLSPort(port int) | Choose an HTTPS port on which to serve requests. | `VK_TLS_PORT`
 UseHTTPPort(port int) | Choose an HTTP port on which to serve requests. When using TLS, the LetsEncrypt challenge server will run on the configured HTTP port. | `VK_HTTP_PORT`
 UseAppName(name string) | When the application starts, `name` will be logged. Empty by default. | `VK_APP_NAME`
 UseEnvPrefix(prefix string) | Use `prefix` instead of `VK` for environment variables, for example `APP_HTTP_PORT` instead of `VK_HTTP_PORT`. | N/A

--- a/vk/optionmodifiers.go
+++ b/vk/optionmodifiers.go
@@ -1,6 +1,8 @@
 package vk
 
 import (
+	"crypto/tls"
+
 	"github.com/suborbital/vektor/vlog"
 )
 
@@ -11,6 +13,14 @@ type OptionsModifier func(*Options)
 func UseDomain(domain string) OptionsModifier {
 	return func(o *Options) {
 		o.Domain = domain
+	}
+}
+
+// UseTLSConfig sets a TLS config that will be used for HTTPS
+// This will take precedence over the Domain option in all cases
+func UseTLSConfig(config *tls.Config) OptionsModifier {
+	return func(o *Options) {
+		o.TLSConfig = config
 	}
 }
 

--- a/vk/optionmodifiers.go
+++ b/vk/optionmodifiers.go
@@ -24,6 +24,13 @@ func UseTLSConfig(config *tls.Config) OptionsModifier {
 	}
 }
 
+// UseTLSPort sets the HTTPS port to be used:
+func UseTLSPort(port int) OptionsModifier {
+	return func(o *Options) {
+		o.TLSPort = port
+	}
+}
+
 // UseHTTPPort sets the HTTP port to be used:
 // If domain is set, HTTP port will be used for LetsEncrypt challenge server
 // If domain is NOT set, this option will put VK in insecure HTTP mode

--- a/vk/options.go
+++ b/vk/options.go
@@ -2,6 +2,7 @@ package vk
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-envconfig"
@@ -10,10 +11,12 @@ import (
 
 // Options are the available options for Server
 type Options struct {
-	AppName   string `env:"_APP_NAME"`
-	Domain    string `env:"_DOMAIN"`
-	HTTPPort  int    `env:"_HTTP_PORT"`
-	EnvPrefix string `env:"-"`
+	AppName   string      `env:"_APP_NAME"`
+	Domain    string      `env:"_DOMAIN"`
+	HTTPPort  int         `env:"_HTTP_PORT"`
+	TLSPort   int         `env:"_TLS_PORT"`
+	TLSConfig *tls.Config `env:"-"`
+	EnvPrefix string      `env:"-"`
 	Logger    *vlog.Logger
 }
 
@@ -35,9 +38,9 @@ func newOptsWithModifiers(mods ...OptionsModifier) *Options {
 	return options
 }
 
-// ShouldUseTLS returns true if domain is set and TLS should be used
+// ShouldUseTLS returns true if domain is set and/or TLS is configured
 func (o *Options) ShouldUseTLS() bool {
-	return o.Domain != ""
+	return o.Domain != "" || o.TLSConfig != nil
 }
 
 // HTTPPortSet returns true if the HTTP port is set
@@ -76,5 +79,9 @@ func (o *Options) replaceFieldsIfNeeded(replacement *Options) {
 
 	if replacement.HTTPPort != 0 {
 		o.HTTPPort = replacement.HTTPPort
+	}
+
+	if replacement.TLSPort != 0 {
+		o.TLSPort = replacement.TLSPort
 	}
 }


### PR DESCRIPTION
This PR allows providing a custom TLS config for VK instances, as well as customizing the port TLS is served on, if desured.

Resolves https://github.com/suborbital/vektor/issues/42