### PR TITLE
router: Expose GlobalOPTIONS from httprouter

### DIFF
--- a/vk/server_options.go
+++ b/vk/server_options.go
@@ -1,0 +1,12 @@
+package vk
+
+import "net/http"
+
+// SetGlobalOPTIONS applies the given http.Handler to all OPTIONS requests. This is useful for CORS preflight requests.
+func (s *Server) SetGlobalOPTIONS(handler http.Handler) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.hrouter.GlobalOPTIONS = handler
+}


### PR DESCRIPTION
This patch allows `GlobalOPTIONS` (from github.com/julienschmidt/httprouter) to be set from within Vektor. 

See this section in [httprouter's README](https://github.com/julienschmidt/httprouter#automatic-options-responses-and-cors) about setting CORS preflight headers for automatic OPTIONS responses. I wasn't able to find a way to achieve the same result using existing Vektor methods.