### PR TITLE
Allow setting 'quiet routes' to muffle router logs

### DIFF
--- a/vk/middleware.go
+++ b/vk/middleware.go
@@ -47,14 +47,6 @@ func enableCors(ctx *Ctx, domain string) {
 	}
 }
 
-func loggerMiddleware() Middleware {
-	return func(r *http.Request, ctx *Ctx) error {
-		ctx.Log.Info(r.Method, r.URL.String())
-
-		return nil
-	}
-}
-
 // generate a HandlerFunc that passes the request through a set of Middleware first and Afterware after
 func augmentHandler(inner HandlerFunc, middleware []Middleware, afterware []Afterware) HandlerFunc {
 	return func(r *http.Request, ctx *Ctx) (interface{}, error) {

--- a/vk/optionmodifiers.go
+++ b/vk/optionmodifiers.go
@@ -71,3 +71,10 @@ func UseInspector(isp func(http.Request)) OptionsModifier {
 		o.PreRouterInspector = isp
 	}
 }
+
+// UseQuietRoutes accepts a list of routes to be 'quiet', i.e. no pre- and post-handler logging
+func UseQuietRoutes(routes ...string) OptionsModifier {
+	return func(o *Options) {
+		o.QuietRoutes = routes
+	}
+}

--- a/vk/options.go
+++ b/vk/options.go
@@ -12,13 +12,14 @@ import (
 
 // Options are the available options for Server
 type Options struct {
-	AppName   string `env:"_APP_NAME"`
-	Domain    string `env:"_DOMAIN"`
-	HTTPPort  int    `env:"_HTTP_PORT"`
-	TLSPort   int    `env:"_TLS_PORT"`
-	TLSConfig *tls.Config
-	EnvPrefix string
-	Logger    *vlog.Logger
+	AppName     string `env:"_APP_NAME"`
+	Domain      string `env:"_DOMAIN"`
+	HTTPPort    int    `env:"_HTTP_PORT"`
+	TLSPort     int    `env:"_TLS_PORT"`
+	TLSConfig   *tls.Config
+	EnvPrefix   string
+	QuietRoutes []string
+	Logger      *vlog.Logger
 
 	PreRouterInspector func(http.Request)
 }

--- a/vk/server.go
+++ b/vk/server.go
@@ -28,6 +28,7 @@ func New(opts ...OptionsModifier) *Server {
 	options := newOptsWithModifiers(opts...)
 
 	router := NewRouter(options.Logger)
+	router.useQuietRoutes(options.QuietRoutes)
 
 	s := &Server{
 		router:  router,
@@ -120,6 +121,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // continuing to serve requests in the background
 func (s *Server) SwapRouter(router *Router) {
 	router.Finalize()
+	router.useQuietRoutes(s.options.QuietRoutes)
 
 	// lock after Finalizing the router so
 	// the lock is released as quickly as possible

--- a/vlog/vlog.go
+++ b/vlog/vlog.go
@@ -140,8 +140,7 @@ func (v *Logger) log(message string, scope interface{}, level int) {
 		defer v.lock.Unlock()
 
 		// throwing away the error here since there's nothing much we can do
-		os.Stdout.Write([]byte(message))
-		os.Stdout.Write([]byte("\n"))
+		os.Stdout.Write(append([]byte(message), []byte("\n")...))
 	}
 
 	structured := structuredLog{
@@ -161,13 +160,12 @@ func (v *Logger) log(message string, scope interface{}, level int) {
 		v.opts.PreLogHook(structuredJSON)
 	}
 
-	_, err = v.output.Write(structuredJSON)
+	structuredOut := append(structuredJSON, []byte("\n")...)
+
+	_, err = v.output.Write(structuredOut)
 	if err != nil {
 		os.Stderr.Write([]byte("[vlog] failed to write to configured output: " + err.Error() + "\n"))
-	} else {
-		v.output.Write([]byte("\n"))
 	}
-
 }
 
 func outputForOptions(opts *Options) (io.Writer, error) {


### PR DESCRIPTION
You can now pass `vk.UseQuietRoutes` to muffle the builtin logs for a given route.