### PR TITLE
feat(router): fallback server to handle any unhandled routes

### DIFF
--- a/vk/optionmodifiers.go
+++ b/vk/optionmodifiers.go
@@ -85,3 +85,10 @@ func UseRouterWrapper(wrapper RouterWrapper) OptionsModifier {
 		o.RouterWrapper = wrapper
 	}
 }
+
+// UseFallbackAddress takes in an address to use as a fallback proxy address
+func UseFallbackAddress(address string) OptionsModifier {
+	return func(o *Options) {
+		o.FallbackAddress = address
+	}
+}

--- a/vk/options.go
+++ b/vk/options.go
@@ -16,15 +16,16 @@ type RouterWrapper func(handler http.Handler) http.Handler
 
 // Options are the available options for Server
 type Options struct {
-	AppName       string `env:"_APP_NAME"`
-	Domain        string `env:"_DOMAIN"`
-	HTTPPort      int    `env:"_HTTP_PORT"`
-	TLSPort       int    `env:"_TLS_PORT"`
-	TLSConfig     *tls.Config
-	EnvPrefix     string
-	QuietRoutes   []string
-	Logger        *vlog.Logger
-	RouterWrapper RouterWrapper
+	AppName         string `env:"_APP_NAME"`
+	Domain          string `env:"_DOMAIN"`
+	HTTPPort        int    `env:"_HTTP_PORT"`
+	TLSPort         int    `env:"_TLS_PORT"`
+	TLSConfig       *tls.Config
+	EnvPrefix       string
+	QuietRoutes     []string
+	Logger          *vlog.Logger
+	RouterWrapper   RouterWrapper
+	FallbackAddress string
 
 	PreRouterInspector func(http.Request)
 }

--- a/vk/router.go
+++ b/vk/router.go
@@ -85,6 +85,7 @@ func (rt *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if rt.fallbackProxy != nil {
 			rt.fallbackProxy.ServeHTTP(w, r)
+			return
 		}
 
 		rt.log.Debug("not handled:", r.Method, r.URL.String())

--- a/vk/router.go
+++ b/vk/router.go
@@ -3,6 +3,8 @@ package vk
 import (
 	"fmt"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"sync"
 	"time"
 
@@ -25,8 +27,9 @@ type Router struct {
 	*RouteGroup                    // the "root" RouteGroup that is mounted at server start
 	hrouter     *httprouter.Router // the internal 'actual' router
 
-	quietRoutes  map[string]bool
-	finalizeOnce sync.Once // ensure that the root only gets mounted once
+	fallbackProxy *httputil.ReverseProxy
+	quietRoutes   map[string]bool
+	finalizeOnce  sync.Once // ensure that the root only gets mounted once
 
 	log *vlog.Logger
 }
@@ -36,13 +39,23 @@ type defaultScope struct {
 }
 
 // NewRouter creates a new Router
-func NewRouter(logger *vlog.Logger) *Router {
+func NewRouter(logger *vlog.Logger, fallback string) *Router {
+	var proxy *httputil.ReverseProxy
+
+	if fallback != "" {
+		proxyURL, _ := url.Parse(fallback)
+		if proxyURL != nil {
+			proxy = httputil.NewSingleHostReverseProxy(proxyURL)
+		}
+	}
+
 	r := &Router{
-		RouteGroup:   Group(""),
-		hrouter:      httprouter.New(),
-		quietRoutes:  map[string]bool{},
-		finalizeOnce: sync.Once{},
-		log:          logger,
+		RouteGroup:    Group(""),
+		hrouter:       httprouter.New(),
+		fallbackProxy: proxy,
+		quietRoutes:   map[string]bool{},
+		finalizeOnce:  sync.Once{},
+		log:           logger,
 	}
 
 	return r
@@ -70,6 +83,10 @@ func (rt *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if handler != nil {
 		handler(w, r, params)
 	} else {
+		if rt.fallbackProxy != nil {
+			rt.fallbackProxy.ServeHTTP(w, r)
+		}
+
 		rt.log.Debug("not handled:", r.Method, r.URL.String())
 
 		// let httprouter handle the fallthrough cases

--- a/vk/server.go
+++ b/vk/server.go
@@ -70,7 +70,7 @@ func (s *Server) Start() error {
 		s.options.Logger.Info("starting", s.options.AppName, "...")
 	}
 
-	s.options.Logger.Info("serving on", s.server.Addr)
+	s.options.Logger.Debug("serving on", s.server.Addr)
 
 	if !s.options.HTTPPortSet() && !s.options.ShouldUseTLS() {
 		s.options.Logger.ErrorString("domain and HTTP port options are both unset, server will start up but fail to acquire a certificate. reconfigure and restart")
@@ -106,7 +106,7 @@ func (s *Server) TestStart() error {
 	s.internalRouter.Finalize()
 
 	if s.options.AppName != "" {
-		s.options.Logger.Info("starting", s.options.AppName, "in Test Mode...")
+		s.options.Logger.Debug("starting", s.options.AppName, "in Test Mode...")
 	}
 
 	s.router = s.options.RouterWrapper(s.internalRouter)
@@ -297,7 +297,7 @@ func goTLSServerWithDomain(options *Options, handler http.Handler) *http.Server 
 }
 
 func goHTTPServerWithPort(options *Options, handler http.Handler) *http.Server {
-	options.Logger.Warn("configured to use HTTP with no TLS")
+	options.Logger.Debug("configured to use HTTP with no TLS")
 
 	s := &http.Server{
 		Addr:    fmt.Sprintf(":%d", options.HTTPPort),

--- a/vk/server.go
+++ b/vk/server.go
@@ -29,7 +29,7 @@ type Server struct {
 func New(opts ...OptionsModifier) *Server {
 	options := newOptsWithModifiers(opts...)
 
-	internalRouter := NewRouter(options.Logger)
+	internalRouter := NewRouter(options.Logger, options.FallbackAddress)
 	internalRouter.useQuietRoutes(options.QuietRoutes)
 
 	s := &Server{

--- a/vk/test/router_swap_test.go
+++ b/vk/test/router_swap_test.go
@@ -36,7 +36,7 @@ func TestRouterSwap(t *testing.T) {
 			AssertBodyString("before")
 	})
 
-	newRouter := vk.NewRouter(logger)
+	newRouter := vk.NewRouter(logger, "")
 	newRouter.GET(p, func(r *http.Request, c *vk.Ctx) (interface{}, error) {
 		return vk.R(200, "after"), nil
 	})


### PR DESCRIPTION
This allows a fallback address to be set where any unhandled requests are forwarded to the fallback server.