### PR TITLE
chore(vektor): Env name underscore is part of prefix, not subordinate fields

### DIFF
--- a/vk/test/cmd/main.go
+++ b/vk/test/cmd/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	server := vk.New(
 		vk.UseAppName("vk tester"),
-		vk.UseEnvPrefix("APP"),
+		vk.UseEnvPrefix("APP_"),
 		vk.UseHTTPPort(9090),
 		vk.UseInspector(func(r http.Request) {
 			fmt.Println("pre-router:", r.URL.Path)

--- a/vk/test/routes_test.go
+++ b/vk/test/routes_test.go
@@ -32,7 +32,7 @@ func (vts *VektorSuite) SetupTest() {
 	server := vk.New(
 		vk.UseLogger(logger),
 		vk.UseAppName("vk tester"),
-		vk.UseEnvPrefix("APP"),
+		vk.UseEnvPrefix("APP_"),
 	)
 
 	test.AddRoutes(server)

--- a/vlog/options.go
+++ b/vlog/options.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sethvargo/go-envconfig"
 )
 
-const defaultEnvPrefix = "VLOG"
+const defaultEnvPrefix = "VLOG_"
 
 // LogLevelTrace and others represent log levels
 const (
@@ -33,9 +33,9 @@ var levelStringMap = map[string]int{
 // Options represents the options for a VLogger
 type Options struct {
 	Level        int
-	LevelString  string `env:"_LOG_LEVEL"`
-	Filepath     string `env:"_LOG_FILE"`
-	LogPrefix    string `env:"_LOG_PREFIX"`
+	LevelString  string `env:"LOG_LEVEL"`
+	Filepath     string `env:"LOG_FILE"`
+	LogPrefix    string `env:"LOG_PREFIX"`
 	OutputWriter io.Writer
 	EnvPrefix    string
 	AppMeta      interface{}


### PR DESCRIPTION
Closes #106 